### PR TITLE
add ref param support

### DIFF
--- a/sonobi-htb.js
+++ b/sonobi-htb.js
@@ -126,7 +126,8 @@ function SonobiHtb(configs) {
         /* build data */
         var data = {
             key_maker: JSON.stringify(keyMaker), // jshint ignore:line
-            cv: 'sbi'
+            cv: 'sbi',
+            ref: __baseClass._configs.ref || Browser.getPageUrl()
         };
 
         return {

--- a/spec/generateRequestObj.spec.js
+++ b/spec/generateRequestObj.spec.js
@@ -70,7 +70,7 @@ describe('generateRequestObj', function () {
     /* -------------------------------------------------------------------- */
 
     /* Instantiate your partner module */
-    var partnerModule = partnerModule(partnerConfig);
+    partnerModule = partnerModule(partnerConfig);
     var partnerProfile = partnerModule.profile;
 
     /* Generate dummy return parcels based on MRA partner profile */
@@ -166,6 +166,10 @@ describe('generateRequestObj', function () {
                     * request params, url, etc.
                     */
                 expect(requestObject).to.exist;
+            });
+
+            it('should contain the ref url', function () {
+                expect(requestObject).to.include.keys('ref');
             });
             /* -----------------------------------------------------------------------*/
         }

--- a/spec/support/mockPartnerConfig.json
+++ b/spec/support/mockPartnerConfig.json
@@ -1,5 +1,6 @@
 {
     "timeout": 1000,
+    "ref": "http://example.com",
     "xSlots": {
         "1": {
             "placementId": "54321",

--- a/spec/support/partnerStub.js
+++ b/spec/support/partnerStub.js
@@ -7,6 +7,7 @@ function Partner(profile, configs, requiredResources, fns) {
     (function __constructor() {
         _configs = {
             timeout: 0,
+            ref: 'http://.example.com',
             lineItemType: profile.lineItemType,
             targetingKeys: profile.targetingKeys,
             rateLimiting: profile.features.rateLimiting


### PR DESCRIPTION
adding an optional config param for publisher called ref. If the ref param is not set we sent Browser.getPageUrl() as the ref param.